### PR TITLE
Link from gh-pages to the actual code repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The amount of overlap, of course, varies based on the height of the sticky heade
 
 ##Take over that scroll.
 
-Do your readers a favor and install The Sticky Pagination Fixer. It captures native pagination-related events, recalculates the height of the viewport, and then scrolls the page to the correct point. Here's a demo.
+Do your readers a favor and install [The Sticky Pagination Fixer](https://github.com/murtaugh/sticky-pagination-fixer). It captures native pagination-related events, recalculates the height of the viewport, and then scrolls the page to the correct point. Here's a demo.
 
 ##Some notes.
 


### PR DESCRIPTION
I googled the space bar scrolling problem and got to the github.io page. I looked for a link to the repo but found none, so I had to google again. This PR adds such a link to save other people some clicks.
